### PR TITLE
Use a extensible type for Maelstrom messages

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -16,6 +16,4 @@ jobs:
         uses: norio-nomura/action-swiftlint@3.2.1
         with:
           args: --strict --config .swiftlint.yml
-        env:
-          DIFF_BASE: ${{ github.base_ref }}
 

--- a/Sources/MaelstromRaft/EchoProvider.swift
+++ b/Sources/MaelstromRaft/EchoProvider.swift
@@ -8,16 +8,16 @@ public actor EchoProvider: MessageProvider {
 
     public init() {}
 
-    public func onMessage(_ message: RPCPacket.Message) async throws -> RPCPacket.Message {
+    public func onMessage(_ message: Message) async throws -> Message {
         switch message {
-            case .`init`:
-                return .initOk
+            case is Maelstrom.Init:
+                return Maelstrom.InitOk()
 
-            case let .echo(echo):
-                return .echoOk(echo)
+            case let echo as Maelstrom.Echo:
+                return Maelstrom.Echo(echo: echo.echo)
 
             default:
-                throw RPCPacket.Error.notSupported
+                throw Maelstrom.Error.notSupported
         }
     }
 }

--- a/Sources/maelstrom-node/main.swift
+++ b/Sources/maelstrom-node/main.swift
@@ -22,7 +22,7 @@ class App {
 
         var config = Configuration(id: 0)
         config.logger = logger
-        let service = MaelstromRPC(group: group, logger: logger, messageProvider: KvNode(configuration: config))
+        let service = try MaelstromRPC(group: group, logger: logger, messageProvider: KvNode(configuration: config))
         lifecycle.register(label: "maelstrom", start: .sync {
             _ = try service.start()
         }, shutdown: .sync {

--- a/Tests/MaelstromRaftTests/KvNodeTests.swift
+++ b/Tests/MaelstromRaftTests/KvNodeTests.swift
@@ -14,8 +14,8 @@ class KvNodeTests: XCTestCase {
         let raft = KvNode(configuration: .init(id: 22))
 
         runAsyncTestAndBlock {
-            let onInit = try await raft.onMessage(.`init`(nodeID: "1", nodeIDs: ["1", "2"]))
-            XCTAssertEqual(onInit, .initOk)
+            let onInit = try await raft.onMessage(Maelstrom.Init(nodeID: "1", nodeIDs: ["1", "2"]))
+            XCTAssertEqual(onInit as? Maelstrom.InitOk, Maelstrom.InitOk())
         }
     }
 
@@ -23,13 +23,13 @@ class KvNodeTests: XCTestCase {
         let raft = KvNode(configuration: .init(id: 22))
 
         runAsyncTestAndBlock {
-            let onInit = try await raft.onMessage(.`init`(nodeID: "1", nodeIDs: ["1", "2"]))
-            XCTAssertEqual(onInit, .initOk)
+            let onInit = try await raft.onMessage(Maelstrom.Init(nodeID: "1", nodeIDs: ["1", "2"]))
+            XCTAssertEqual(onInit as? Maelstrom.InitOk, Maelstrom.InitOk())
             do {
-                _ = try await raft.onMessage(.read(key: 123))
+                _ = try await raft.onMessage(Maelstrom.Read(key: 123))
                 XCTFail("Read non existing key should throw an error")
             } catch {
-                XCTAssertEqual(error as? RPCPacket.Error, .keyDoesNotExist)
+                XCTAssertEqual(error as? Maelstrom.Error, .keyDoesNotExist)
             }
         }
     }

--- a/Tests/MaelstromRaftTests/MessageHandlerTests.swift
+++ b/Tests/MaelstromRaftTests/MessageHandlerTests.swift
@@ -21,25 +21,29 @@ class MessageHandlerTests: XCTestCase {
             echoHandler
         ]).wait()
 
-        let request = RPCPacket(src: "t0", dest: "n1", id: 0, body: .`init`(nodeID: "n1", nodeIDs: ["n1", "n2"]), msgID: 5)
+        let request = RPCPacket(src: "t0", dest: "n1", id: 0, body: Maelstrom.Init(nodeID: "n1", nodeIDs: ["n1", "n2"]), msgID: 5)
         let context = try channel.pipeline.context(handlerType: MessageHandler.self).wait()
         echoHandler.channelRead(context: context, data: NIOAny(request))
 
-        if let response = try channel.readOutbound(as: RPCPacket.self) {
-            XCTAssertEqual(response.src, request.dest)
-            XCTAssertEqual(response.dest, request.src)
-            switch response.body {
-                case .initOk:
-                    XCTAssertEqual(response.dest, "t0")
-                    XCTAssertEqual(response.src, "n1")
-                    XCTAssertEqual(response.msgID, 1)
-                    XCTAssertEqual(response.internalBody.inReplyTo, 5)
-                default:
-                    XCTFail("On init message should answer `init_ok`")
+        // Sleep in this thread and schedule a next task on the event loop
+        // Need to sync actors Task and response in NIO event loop
+        sleep(1)
+        context.eventLoop.execute {
+            if let response = try? channel.readOutbound(as: RPCPacket.self) {
+                XCTAssertEqual(response.src, request.dest)
+                XCTAssertEqual(response.dest, request.src)
+                switch response.body {
+                    case is Maelstrom.InitOk:
+                        XCTAssertEqual(response.dest, "t0")
+                        XCTAssertEqual(response.src, "n1")
+                        XCTAssertEqual(response.msgID, 1)
+                        XCTAssertEqual(response.internalBody.inReplyTo, 5)
+                    default:
+                        XCTFail("On init message should answer `init_ok`")
+                }
+            } else {
+                XCTFail("couldn't read from channel")
             }
-        } else {
-            XCTFail("couldn't read from channel")
         }
-        XCTAssertNoThrow(XCTAssertNil(try channel.readOutbound()))
     }
 }


### PR DESCRIPTION
Instead of fixed enum with RPC messages provide a place for extending
RPC messages. This is done with a base protocol and several structures
that implement this base protocol